### PR TITLE
fix azure and aws TOC rendering

### DIFF
--- a/docs/services/aws-services-guide.md
+++ b/docs/services/aws-services-guide.md
@@ -1,5 +1,8 @@
 ---
-title: Using AWS Services toc: true weight: 430 indent: true
+title: Using AWS Services
+toc: true
+weight: 430
+indent: true
 ---
 
 # Deploying Wordpress in Amazon Web Services (AWS)

--- a/docs/services/azure-services-guide.md
+++ b/docs/services/azure-services-guide.md
@@ -1,5 +1,8 @@
 ---
-title: Using Azure Services toc: true weight: 440 indent: true
+title: Using Azure Services
+toc: true
+weight: 440
+indent: true
 ---
 # Deploying Wordpress in Azure
 


### PR DESCRIPTION
Fixes Jekyll rendering error resulting is missing TOC entries:

![image](https://user-images.githubusercontent.com/284840/67613512-3edcee00-f763-11e9-9768-ddd2256a6f3c.png)

```
make run_docs_local
```

gives the following
```
 Incremental build: disabled. Enable with --incremental
      Generating...
YAML Exception reading /srv/jekyll/docs/local/services/azure-services-guide.md: (<unknown>): mapping values are not allowed in this context at line 2 column 32
YAML Exception reading /srv/jekyll/docs/local/services/aws-services-guide.md: (<unknown>): mapping values are not allowed in this context at line 2 column 30
                    done in 24.408 seconds.
```